### PR TITLE
getBooksOnShelf doesn't require authentication

### DIFF
--- a/lib/goodreads-api.js
+++ b/lib/goodreads-api.js
@@ -779,7 +779,6 @@ var Goodreads = function Goodreads(credentials, callbackURL) {
   function getBooksOnUserShelf(id, shelf, queryOptions) {
     var fn_name = 'getBooksOnUserShelf()';
 
-    if (!OAUTHENTICATED) return Promise.reject(noOAuthError(fn_name));
     if (!id) return Promise.reject(wrongParamsError(fn_name, 'userID'));
     if (!shelf) return Promise.reject(wrongParamsError(fn_name, 'shelf'));
 
@@ -790,11 +789,10 @@ var Goodreads = function Goodreads(credentials, callbackURL) {
       key: KEY,
       format: 'xml'
     }, queryOptions);
-    var authOptions = _getAuthOptions();
 
-    var req = Request.builder().withPath(path).withQueryParams(options).withOAuth(authOptions).build();
+    var req = Request.builder().withPath(path).withQueryParams(options).build();
 
-    return _execute(oAuthGet, req);
+    return _execute(get, req);
   };
 
   /**

--- a/src/goodreads-api.js
+++ b/src/goodreads-api.js
@@ -872,7 +872,6 @@ const Goodreads = function(credentials, callbackURL) {
   function getBooksOnUserShelf(id, shelf, queryOptions) {
     const fn_name = 'getBooksOnUserShelf()';
 
-    if (!OAUTHENTICATED) return Promise.reject(noOAuthError(fn_name));
     if (!id) return Promise.reject(wrongParamsError(fn_name, 'userID'));
     if (!shelf) return Promise.reject(wrongParamsError(fn_name, 'shelf'));
 
@@ -884,15 +883,13 @@ const Goodreads = function(credentials, callbackURL) {
       format: 'xml',
       ...queryOptions,
     };
-    const authOptions = _getAuthOptions();
 
     const req = Request.builder()
     .withPath(path)
     .withQueryParams(options)
-    .withOAuth(authOptions)
     .build();
 
-    return _execute(oAuthGet, req);
+    return _execute(get, req);
   };
 
   /**


### PR DESCRIPTION
Hi!

I'm using your api wrapper here to grab the books on a user's shelf and I noticed you're unnecessarily (as far as i understand) adding auth to the request to the /reviews/list endpoint. If this was an intentional design choice, feel free to ignore this. I just didn't feel like mucking about with oauth for the thing I'm trying to do, and since I made the change I figured I might as well submit a PR.

Cheers!
Jordan

