### PR TITLE
Export methods to save oauth tokens between sessions

### DIFF
--- a/lib/goodreads-api.js
+++ b/lib/goodreads-api.js
@@ -109,7 +109,7 @@ var Goodreads = function Goodreads(credentials, callbackURL) {
    * @returns {undefined}
    */
   function initOAuth(callbackURL) {
-    if (!callbackURL) logWarning('Warning: You have passed no callbackURL.', 'initOauth()');
+    if (!callbackURL) logWarning('Warning: You have passed no callbackURL.', 'initOAuth()');
 
     var requestURL = URL + '/oauth/request_token';
     var accessURL = URL + '/oauth/access_token';
@@ -165,6 +165,39 @@ var Goodreads = function Goodreads(credentials, callbackURL) {
       } else reject(new GoodreadsApiError("No Request Token found. call getRequestToken()"));
     });
   };
+
+  /**
+   * setAccessToken - call this if you have a key-pair saved from a previous
+   * session.
+   *
+   * @access public
+   */
+  function setAccessToken(_ref) {
+    var token = _ref.token,
+        secret = _ref.secret;
+
+    _setAccessToken({
+      ACCESS_TOKEN: token,
+      ACCESS_TOKEN_SECRET: secret
+    });
+    OAUTHENTICATED = true;
+  }
+
+  /**
+   * dumpAccessToken - call this to get ahold of the key-pair to save it
+   * for future sessions.
+   *
+   * @access public
+   */
+  function dumpAccessToken(_ref2) {
+    var token = _ref2.token,
+        secret = _ref2.secret;
+
+    return {
+      token: ACCESS_TOKEN,
+      secret: ACCESS_TOKEN_SECRET
+    };
+  }
 
   /**
    * followAuthor
@@ -959,6 +992,8 @@ var Goodreads = function Goodreads(credentials, callbackURL) {
     initOAuth: initOAuth,
     getRequestToken: getRequestToken,
     getAccessToken: getAccessToken,
+    setAccessToken: setAccessToken,
+    dumpAccessToken: dumpAccessToken,
     _setOAuthToken: _setOAuthToken,
     getBooksByAuthor: getBooksByAuthor,
     getAuthorInfo: getAuthorInfo,

--- a/src/goodreads-api.js
+++ b/src/goodreads-api.js
@@ -153,6 +153,33 @@ const Goodreads = function(credentials, callbackURL) {
   };
 
   /**
+   * setAccessToken - call this if you have a key-pair saved from a previous
+   * session.
+   *
+   * @access public
+   */
+  function setAccessToken({token, secret}) {
+    _setAccessToken({
+      ACCESS_TOKEN: token,
+      ACCESS_TOKEN_SECRET: secret
+    });
+    OAUTHENTICATED = true;
+  }
+
+  /**
+   * dumpAccessToken - call this to get ahold of the key-pair to save it
+   * for future sessions.
+   *
+   * @access public
+   */
+  function dumpAccessToken({ token, secret }) {
+    return {
+      token: ACCESS_TOKEN,
+      secret: ACCESS_TOKEN_SECRET
+    };
+  }
+
+  /**
    * followAuthor
    *
    * @access public
@@ -1083,6 +1110,8 @@ const Goodreads = function(credentials, callbackURL) {
     initOAuth,
     getRequestToken,
     getAccessToken,
+    setAccessToken,
+    dumpAccessToken,
     _setOAuthToken,
     getBooksByAuthor,
     getAuthorInfo,


### PR DESCRIPTION
I'd like to use this library from a backup script, where I can't approve OAuth access each time.

I've added two methods (`setAccessToken` and `dumpAccessToken`) to auth once and save the access token.

I use 'em like this:
```js
const gr = goodreads({
  key: settings.GOODREADS_APP_KEY,
  secret: settings.GOODREADS_APP_SECRET
});
gr.initOAuth();
const oauthUrl = await gr.getRequestToken();
console.log(`open ${oauthUrl}`);
console.log(`then press any key to continue`);
await new Promise(resolve => process.stdin.once('data', resolve));
await gr.getAccessToken();
console.log(gr.dumpAccessToken());
```

Then in future non-interactive runs:
```js
const gr = goodreads({
  key: settings.GOODREADS_APP_KEY,
  secret: settings.GOODREADS_APP_SECRET
});
gr.initOAuth();
gr.setAccessToken({
  token: settings.GOODREADS_OAUTH_TOKEN,
  secret: settings.GOODREADS_OAUTH_SECRET
});
```