### PR TITLE
added searchBooks to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,12 @@ You can pass an optional `page` parameter specifying the result page you want to
 
 ##### showBook(bookID)
 
-
-
+#### searchBooks([params]);
+  #### @param {object} params q: query, page: page of results, field: one of 'title', 'author' or 'all' (default)
+  #### Example Usage:
+  ```js
+    const res = await goodreads.searchBooks( { q: 'A song of ice and fire', page: 2, field: 'title' } );
+  ```
 
 ## OAuth authentication and methods
 


### PR DESCRIPTION
I mean, that's probably one of the most common use cases of this package.

I would suggest that adding line 77 ( #### searchBooks([params]); ) is a necessity,
And a bit more details regarding the params or an example usage for just a few functions wouldn't really hurt either IMO, but obviously I get it if you'll dismiss lines 78-82 from the PR.

Thank you.